### PR TITLE
Fix #76: Show only the first of multiple categories

### DIFF
--- a/classes/RSS.php
+++ b/classes/RSS.php
@@ -72,7 +72,7 @@ class RSS {
                   'title' => $item->find('title')->text(),
                   'link' => $item->find('link')->text(),
                   'date' => $published,
-                  'category' => $item->find('category')->text(),
+                  'category' => $item->find('category:first')->text(),
                   'body' => $item->find('description')->text(),
       ];
     }


### PR DESCRIPTION
RSS does not distinguish between hierarchical and tag vocabularies,
but a best guess is that the primary category occurs first.